### PR TITLE
Document error email handler environment behavior

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,12 +111,15 @@ APP_SMTP_ENCRYPTION=""
 APP_SMTP_USERNAME=""
 APP_SMTP_PASSWORD=""
 
-# Send error logs via email
-APP_LOG_MAIL_RECIPIENT=""
-APP_LOG_MAIL_SUBJECT=""
-APP_LOG_MAIL_SENDER=""
-APP_LOG_MAIL_LEVEL=""
+# Send error logs via email (set on LIVE only, omit on dev/test to disable)
+APP_LOG_MAIL_RECIPIENT="admin@example.com"
+APP_LOG_MAIL_SUBJECT="Error on MyApp LIVE"
+APP_LOG_MAIL_SENDER="noreply@example.com"
+APP_LOG_MAIL_LEVEL="error"  # info / warning / error
 ```
+
+**Note:** The error email handler only activates when ALL four `APP_LOG_MAIL_*` vars are set.
+To disable error emails on dev/test environments, simply don't define these variables.
 
 ## Show Block design/thumbnails instead of icons in admin UI (Elemental)
 

--- a/_config/email.yml
+++ b/_config/email.yml
@@ -70,7 +70,15 @@ SilverStripe\Core\Injector\Injector:
       AuthMode: [ setAuthMode, ['login'] ]
 
 
-# Add email error handler (if no Sentry etc)
+# Email error handler - sends error emails via NativeMailerHandler
+# Only activates when ALL env vars below are set. To disable on dev/test,
+# simply don't define these vars in those environments.
+#
+# Required in .env (on live only):
+#   APP_LOG_MAIL_RECIPIENT="admin@example.com"
+#   APP_LOG_MAIL_SUBJECT="Error on MyApp"
+#   APP_LOG_MAIL_SENDER="noreply@example.com"
+#   APP_LOG_MAIL_LEVEL="error"  # info / warning / error
 ---
 Name: admintweaks-error-email-logger
 Only:


### PR DESCRIPTION
Cherry-pick from 3.0 branch.

Clarify that error emails only activate when all `APP_LOG_MAIL_*` env vars are set - omit these on dev/test to disable error emails.